### PR TITLE
TCpuBuffer and TCpuTensor Integration

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuBuffer.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuBuffer.h
@@ -66,6 +66,22 @@ public:
 
     operator AFloat * () const {return (* fBuffer) + fOffset;}
 
+    class FakeIteratorBegin{
+    private:
+      AFloat& fBeginRet;
+    public:
+      FakeIteratorBegin(AFloat& x): fBeginRet(x){}
+      AFloat& operator*()
+      {
+         return fBeginRet;
+      }
+    };
+    FakeIteratorBegin begin(){
+      return FakeIteratorBegin((*fBuffer.get())[fOffset]);
+   }
+
+
+
     /** Return sub-buffer of size \p start starting at element \p offset. */
     TCpuBuffer GetSubBuffer(size_t offset, size_t start) const;
 
@@ -80,7 +96,7 @@ public:
     void CopyTo(TCpuBuffer &);
 
     /**
-     * copy pointer from an external 
+     * copy pointer from an external
      */
 
     size_t GetSize() const {return fSize;}
@@ -92,4 +108,3 @@ public:
 } // namespace TMVA
 
 #endif
-

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuBuffer.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu/CpuBuffer.h
@@ -76,8 +76,8 @@ public:
          return fBeginRet;
       }
     };
-    FakeIteratorBegin begin(){
-      return FakeIteratorBegin((*fBuffer.get())[fOffset]);
+    FakeIteratorBegin begin(){      
+      return FakeIteratorBegin(*((* fBuffer) + fOffset));
    }
 
 

--- a/tmva/tmva/inc/TMVA/RTensor.hxx
+++ b/tmva/tmva/inc/TMVA/RTensor.hxx
@@ -176,6 +176,9 @@ private:
    Value_t *fData;
    std::shared_ptr<Container_t> fContainer;
 
+protected:
+   void ReshapeInplace(const Shape_t &shape);
+
 public:
    // Constructors
 
@@ -301,6 +304,33 @@ public:
       return Iterator(*this, fSize);
    }
 };
+
+/// \brief Reshape tensor in place
+/// \param[in] shape Shape vector
+/// Reshape tensor without changing the overall size
+template <typename Value_t, typename Container_t>
+inline void RTensor<Value_t, Container_t>::ReshapeInplace(const Shape_t &shape)
+{
+   const auto size = Internal::GetSizeFromShape(shape);
+   if (size != fSize) {
+      std::stringstream ss;
+      ss << "Cannot reshape tensor with size " << fSize << " into shape { ";
+      for (std::size_t i = 0; i < shape.size(); i++) {
+         if (i != shape.size() - 1) {
+            ss << shape[i] << ", ";
+         } else {
+            ss << shape[i] << " }.";
+         }
+      }
+      throw std::runtime_error(ss.str());
+   }
+
+   // Compute new strides from shape
+   auto strides = Internal::ComputeStridesFromShape(shape, fLayout);
+   fShape = shape;
+   fStrides = strides;
+}
+
 
 /// \brief Access elements
 /// \param[in] idx Index vector
@@ -445,27 +475,9 @@ inline RTensor<Value_t, Container_t> RTensor<Value_t, Container_t>::ExpandDims(i
 template <typename Value_t, typename Container_t>
 inline RTensor<Value_t, Container_t> RTensor<Value_t, Container_t>::Reshape(const Shape_t &shape)
 {
-   const auto size = Internal::GetSizeFromShape(shape);
-   if (size != fSize) {
-      std::stringstream ss;
-      ss << "Cannot reshape tensor with size " << fSize << " into shape { ";
-      for (std::size_t i = 0; i < shape.size(); i++) {
-         if (i != shape.size() - 1) {
-            ss << shape[i] << ", ";
-         } else {
-            ss << shape[i] << " }.";
-         }
-      }
-      throw std::runtime_error(ss.str());
-   }
-
-   // Compute new strides from shape
-   auto strides = Internal::ComputeStridesFromShape(shape, fLayout);
-
-   // Create copy, attach new shape and strides and return
+   // Create copy, replace and return
    RTensor<Value_t, Container_t> x(*this);
-   x.fShape = shape;
-   x.fStrides = strides;
+   x.ReshapeInplace(shape);
    return x;
 }
 


### PR DESCRIPTION
Modify TCpuBuffer, adding a (fake) iterator interface with Begin() so that RTensor can use it as container.
Modify TCpuTensor so that it derives from RTensor so as to enforce common interface.